### PR TITLE
Use `FuturesUnordered` instead of manually pocking futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,12 +210,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -223,6 +239,34 @@ name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -242,10 +286,16 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -876,6 +926,7 @@ dependencies = [
  "bytes",
  "clap",
  "env_logger",
+ "futures",
  "log",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1.0.66"
 bytes = "1.2.1"
 clap = { version = "4.0.18", features = ["derive"] }
 env_logger = "0.9.1"
+futures = "0.3.25"
 log = "0.4.17"
 regex = "1.6.0"
 reqwest = "0.11.12"

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -157,13 +157,17 @@ impl Scheduler {
     }
 
     pub async fn check_requests(&mut self) {
+        while self.check_one_request().await {}
+    }
+
+    pub async fn check_one_request(&mut self) -> bool {
         let result = match timeout(Duration::ZERO, self.requests.next()).await {
             Ok(r) => r,
-            Err(_) => return,
+            Err(_) => return false,
         };
         let result = match result {
             Some(r) => r,
-            None => return,
+            None => return false,
         };
         match result {
             Ok((url_id, response_result)) => match response_result {
@@ -175,16 +179,21 @@ impl Scheduler {
             },
             Err(err) => error!("Request: {}", err),
         }
+        true
     }
 
-    async fn check_processes(&mut self) {
+    pub async fn check_processes(&mut self) {
+        while self.check_one_process().await {}
+    }
+
+    pub async fn check_one_process(&mut self) -> bool {
         let result = match timeout(Duration::ZERO, self.processes.next()).await {
             Ok(r) => r,
-            Err(_) => return,
+            Err(_) => return false,
         };
         let result = match result {
             Some(r) => r,
-            None => return,
+            None => return false,
         };
         match result {
             Ok((url_id, process_result)) => match process_result {
@@ -196,6 +205,7 @@ impl Scheduler {
             },
             Err(err) => error!("Request: {}", err),
         }
+        true
     }
 
     async fn process_response(&mut self, url_id: usize, response: Response) {


### PR DESCRIPTION
Previously, I called `is_finished` on each `JoinHandle` to check if it has finished. This changes to use `FuturesUnordered` using its `.next()` from trait `StreamExt` with a combination of `timeout(Duration::ZERO, …)` to prevent waiting.

- Should be faster since no popping from vectors of `JoinHandle`s are done anymore.
- Uses significantly less CPU because no looping through `JoinHandle`s are done and instead we rely on `FuturesUnordered`.
- Better request spawning handling.
- Introduced helper function `recursive_scraper::schedule::Scheduler::delaying_requests`.